### PR TITLE
Testnet initialize and recover

### DIFF
--- a/contracts/liquidity-pool/examples/schema.rs
+++ b/contracts/liquidity-pool/examples/schema.rs
@@ -3,7 +3,9 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use liquidity_pool::msg::{ConfigResponse, HandleMsg, InitMsg, QueryMsg, ReserveResponse, ReceiveMsg};
+use liquidity_pool::msg::{
+    ConfigResponse, HandleMsg, InitMsg, QueryMsg, ReceiveMsg, ReserveResponse,
+};
 use liquidity_pool::state::Config;
 
 fn main() {

--- a/contracts/liquidity-pool/examples/schema.rs
+++ b/contracts/liquidity-pool/examples/schema.rs
@@ -3,7 +3,7 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use liquidity_pool::msg::{ConfigResponse, HandleMsg, InitMsg, QueryMsg, ReserveResponse};
+use liquidity_pool::msg::{ConfigResponse, HandleMsg, InitMsg, QueryMsg, ReserveResponse, ReceiveMsg};
 use liquidity_pool::state::Config;
 
 fn main() {
@@ -18,4 +18,5 @@ fn main() {
     export_schema(&schema_for!(Config), &out_dir);
     export_schema(&schema_for!(ConfigResponse), &out_dir);
     export_schema(&schema_for!(ReserveResponse), &out_dir);
+    export_schema(&schema_for!(ReceiveMsg), &out_dir);
 }

--- a/contracts/liquidity-pool/schema/handle_msg.json
+++ b/contracts/liquidity-pool/schema/handle_msg.json
@@ -3,6 +3,19 @@
   "title": "HandleMsg",
   "anyOf": [
     {
+      "description": "Implementaton cw20 receive msg",
+      "type": "object",
+      "required": [
+        "receive"
+      ],
+      "properties": {
+        "receive": {
+          "$ref": "#/definitions/Cw20ReceiveMsg"
+        }
+      }
+    },
+    {
+      "description": "Initialize an asset on the money market",
       "type": "object",
       "required": [
         "init_asset"
@@ -23,6 +36,7 @@
       }
     },
     {
+      "description": "Callback sent from maToken contract after instantiated",
       "type": "object",
       "required": [
         "init_asset_token_callback"
@@ -35,7 +49,7 @@
           ],
           "properties": {
             "id": {
-              "description": "Either the Ticker for a terra native asset or address for a cw20 token",
+              "description": "Either the symbol for a terra native asset or address for a cw20 token",
               "type": "string"
             }
           }
@@ -63,5 +77,43 @@
         }
       }
     }
-  ]
+  ],
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "Cw20ReceiveMsg": {
+      "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a HandleMsg",
+      "type": "object",
+      "required": [
+        "amount",
+        "sender"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "msg": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Binary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sender": {
+          "$ref": "#/definitions/HumanAddr"
+        }
+      }
+    },
+    "HumanAddr": {
+      "type": "string"
+    },
+    "Uint128": {
+      "type": "string"
+    }
+  }
 }

--- a/contracts/liquidity-pool/schema/receive_msg.json
+++ b/contracts/liquidity-pool/schema/receive_msg.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ReceiveMsg",
+  "anyOf": [
+    {
+      "description": "Redeem the sent tokens for",
+      "type": "object",
+      "required": [
+        "redeem"
+      ],
+      "properties": {
+        "redeem": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "description": "Either the symbol for a terra native asset or address for a cw20 token",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -46,8 +46,9 @@ export async function deploy(terra, wallet) {
   let ma_code_id = await upload_contract(terra, wallet, './artifacts/ma_token.wasm');
   console.log("Uploaded wa_token contract");
 
+
   const lp_init_msg = {"ma_token_code_id": ma_code_id};
-  const lp_contract_address = await deploy_contract(terra, wallet,'./artifacts/liquidity_pool.wasm', lp_init_msg)
+  const lp_contract_address = await deploy_contract(terra, wallet,'./artifacts/liquidity_pool.wasm', lp_init_msg);
   console.log("Uploaded and instantiated liquidity_pool contract");
 
   const lp_luna_execute_msg = {"init_asset": {"symbol": "luna"}};

--- a/scripts/integration_tests.js
+++ b/scripts/integration_tests.js
@@ -48,11 +48,33 @@ async function test_deposit(terra, wallet, contract_address) {
   console.log(result);
 }
 
+async function test_redeem(terra, wallet, contract_address) {
+  let reserve_query_msg = {"reserve": {"symbol": "luna"}};
+  let { ma_token_address } = await query_contract(terra, contract_address, reserve_query_msg);
+
+  const receive_msg = {
+    "redeem":
+    {"id": "luna"}
+  }
+
+  const execute_msg = {"send": {"contract": contract_address, "amount": 500, receive_msg}}
+  const send_msg = new MsgExecuteContract(wallet.key.accAddress, ma_token_address, execute_msg);
+  await perform_transaction(terra, wallet, send_msg);
+
+  // const balance_query_msg = {"balance": {"address": wallet.key.accAddress}};
+  // let result = await query_contract(terra, ma_token_address, balance_query_msg);
+  // console.log(result);
+  // verify ma_balance is 500 and uluna is 500 (converted 1:1)
+}
+
 const terra = new LocalTerra();
 const wallet = terra.wallets.test1;
-const contract_address = await deploy(terra, wallet);
+// const result = await deploy(terra, wallet);
+// const lp_contract_address = result.lp_contract_address;
+const lp_contract_address = 'terra13urdf0tt35xhlzna4kw4l05cfjpcxlphc75cgt';
 
-await test_reserve_query(terra, contract_address, "usd")
-await test_reserve_query(terra, contract_address, "luna");
-await test_config_query(terra, contract_address);
-test_deposit(terra, wallet, contract_address);
+// await test_reserve_query(terra, lp_contract_address, "usd")
+// await test_reserve_query(terra, lp_contract_address, "luna");
+// await test_config_query(terra, lp_contract_address);
+// await test_deposit(terra, wallet, lp_contract_address);
+await test_redeem(terra, wallet, lp_contract_address);

--- a/scripts/integration_tests.js
+++ b/scripts/integration_tests.js
@@ -52,29 +52,25 @@ async function test_redeem(terra, wallet, contract_address) {
   let reserve_query_msg = {"reserve": {"symbol": "luna"}};
   let { ma_token_address } = await query_contract(terra, contract_address, reserve_query_msg);
 
-  const receive_msg = {
-    "redeem":
-    {"id": "luna"}
-  }
+  //encode in base64
+  const receive_msg = {"redeem": {"id": "luna"}};
 
-  const execute_msg = {"send": {"contract": contract_address, "amount": 500, receive_msg}}
+  const execute_msg = {"send": {"contract": contract_address, "amount": "500", receive_msg}};
   const send_msg = new MsgExecuteContract(wallet.key.accAddress, ma_token_address, execute_msg);
   await perform_transaction(terra, wallet, send_msg);
 
-  // const balance_query_msg = {"balance": {"address": wallet.key.accAddress}};
-  // let result = await query_contract(terra, ma_token_address, balance_query_msg);
-  // console.log(result);
+  const balance_query_msg = {"balance": {"address": wallet.key.accAddress}};
+  let result = await query_contract(terra, ma_token_address, balance_query_msg);
+  console.log(result);
   // verify ma_balance is 500 and uluna is 500 (converted 1:1)
 }
 
 const terra = new LocalTerra();
 const wallet = terra.wallets.test1;
-// const result = await deploy(terra, wallet);
-// const lp_contract_address = result.lp_contract_address;
-const lp_contract_address = 'terra13urdf0tt35xhlzna4kw4l05cfjpcxlphc75cgt';
+const lp_contract_address = await deploy(terra, wallet);
 
-// await test_reserve_query(terra, lp_contract_address, "usd")
-// await test_reserve_query(terra, lp_contract_address, "luna");
-// await test_config_query(terra, lp_contract_address);
-// await test_deposit(terra, wallet, lp_contract_address);
+await test_reserve_query(terra, lp_contract_address, "usd")
+await test_reserve_query(terra, lp_contract_address, "luna");
+await test_config_query(terra, lp_contract_address);
+await test_deposit(terra, wallet, lp_contract_address);
 await test_redeem(terra, wallet, lp_contract_address);

--- a/scripts/testnet.mjs
+++ b/scripts/testnet.mjs
@@ -1,20 +1,17 @@
-import {LCDClient, MnemonicKey, MsgSend, Wallet} from "@terra-money/terra.js";
+import {LCDClient, MnemonicKey} from "@terra-money/terra.js";
 
-export function initialize(mnemonic) {
-  const mk = new MnemonicKey({mnemonic: mnemonic});
-  const wallet = terra.wallet(mk);
+export function initialize() {
+  const mk = new MnemonicKey();
 
-  let accountAddress = wallet.key.accAddress
-  let publicKey = wallet.key.accPubKey
+  console.log(`Account Address: ${mk.accAddress}`);
+  console.log(`MnemonicKey: ${mk.mnemonic}`);
 
-  console.log(`Account Address: ${accountAddress}`)
-  console.log(`Public Key: ${publicKey}`)
-
-  return wallet
+  return terra.wallet(mk);
 }
 
 export function recover(mnemonic) {
   const mk = new MnemonicKey({mnemonic: mnemonic});
+  console.log(mk.accAddress);
   return terra.wallet(mk);
 }
 
@@ -23,4 +20,6 @@ const terra = new LCDClient({
   chainID: 'tequila-0004'
 });
 
+const wallet = initialize();
+// const wallet = await recover(process.env.TEST_MAIN);
 


### PR DESCRIPTION
Fixed the testnet initialize and recover workflow. This is done using the mnemonic key. In initialization, the mnemonic is generated and printed to the console. The user of the script should then save this in a .env file. To recover an account, the user can then pass in the .env variable to the recover function which returns the associated wallet.