### PR TITLE
Setup function

### DIFF
--- a/scripts/deploy_local.js
+++ b/scripts/deploy_local.js
@@ -1,9 +1,11 @@
-import { deploy } from "./helpers.mjs";
+import {deploy, setup} from "./helpers.mjs";
 import { LocalTerra } from "@terra-money/terra.js";
 
 const terra = new LocalTerra();
 const wallet = terra.wallets.test1;
-deploy(terra, wallet);
+let lpContractAddress = await deploy(terra, wallet);
 
+const initialAssets = ["luna", "usd", "mnt", "krw", "sdt"];
+await setup(terra, wallet, lpContractAddress, {initialAssets});
 
 

--- a/scripts/helpers.mjs
+++ b/scripts/helpers.mjs
@@ -51,15 +51,18 @@ export async function deploy(terra, wallet) {
 
   console.log("Uploaded and instantiated liquidity_pool contract");
 
-  const lpLunaExecuteMsg = {"init_asset": {"symbol": "luna"}};
-  const lpUsdExecuteMsg = {"init_asset": {"symbol": "usd"}};
-
-  await executeContract(terra, wallet, lpContractAddress, lpLunaExecuteMsg);
-  await executeContract(terra, wallet, lpContractAddress, lpUsdExecuteMsg);
-  console.log("Initialized luna and usd assets for liquidity_pool");
-
   console.log("LP Contract Address: " + lpContractAddress);
   return lpContractAddress;
+}
+
+export async function setup(terra, wallet, contractAddress, options) {
+  const initialAssets = options.initialAssets ?? [];
+
+  for (let asset of initialAssets) {
+    let initAssetMsg = {"init_asset": {"symbol": asset}};
+    await executeContract(terra, wallet, contractAddress, initAssetMsg);
+    console.log("Initialized " + asset);
+  }
 }
 
 

--- a/scripts/integration_tests.js
+++ b/scripts/integration_tests.js
@@ -1,5 +1,5 @@
 import {Coin, LocalTerra, MsgExecuteContract} from "@terra-money/terra.js";
-import {deploy, performTransaction, queryContract} from "./helpers.mjs";
+import {deploy, performTransaction, queryContract, setup} from "./helpers.mjs";
 
 
 function toEncodedBinary(object) {
@@ -22,6 +22,8 @@ async function main() {
   const wallet = terra.wallets.test1;
 
   const lpContractAddress = await deploy(terra, wallet);
+  const initialAssets = ["luna", "usd"];
+  await setup(terra, wallet, lpContractAddress, {initialAssets});
 
   await testReserveQuery(terra, lpContractAddress, "usd")
   await testReserveQuery(terra, lpContractAddress, "luna");


### PR DESCRIPTION
Created a setup function that is meant to be called to setup the desired environment. It accepts an options object which currently only supports initializing an array of assets. This is called from deploy_local and integration_tests after the deploy method.